### PR TITLE
Omit deprecated "U" file mode for Python 3.11

### DIFF
--- a/pydarkstar/itemlist.py
+++ b/pydarkstar/itemlist.py
@@ -85,7 +85,7 @@ class ItemList(DarkObject):
 
         self.info('load %s', fname)
         line_number = 0
-        with open(fname, 'rU') as handle:
+        with open(fname, 'r') as handle:
             # first line is item titles
             line = handle.readline()
             line_number += 1


### PR DESCRIPTION
Under Python 3.11, broker.py fails to execute with the message:

ValueError: invalid mode: 'rU'
