### PR TITLE
Add ability to input a csv file and expand scrub to all exposed ffxiah categories

### DIFF
--- a/ffxiahbot/apps/scrub.py
+++ b/ffxiahbot/apps/scrub.py
@@ -3,6 +3,7 @@ Create item database.
 """
 
 import asyncio
+import csv
 from pathlib import Path
 from typing import Annotated, cast
 
@@ -22,9 +23,61 @@ ServerIDOption = Option(
 )
 
 
+def _load_item_ids_from_csv(path: Path) -> list[int]:
+    """Load item IDs from a CSV with an itemid column."""
+    if not path.exists():
+        raise FileNotFoundError(f"input CSV does not exist: {path}")
+
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+
+        if reader.fieldnames is None:
+            raise ValueError(f"CSV has no header row: {path}")
+
+        header_map = {name.strip().lower(): name for name in reader.fieldnames}
+        if "itemid" not in header_map:
+            raise ValueError(
+                f"CSV is missing required 'itemid' column: {path}\n"
+                f"found columns: {', '.join(reader.fieldnames)}"
+            )
+
+        itemid_col = header_map["itemid"]
+
+        item_ids: list[int] = []
+        seen: set[int] = set()
+
+        for row_num, row in enumerate(reader, start=2):
+            raw = str(row.get(itemid_col, "")).strip()
+            if not raw:
+                continue
+
+            try:
+                item_id = int(raw)
+            except ValueError:
+                logger.warning("skipping non-integer itemid on row %d: %r", row_num, raw)
+                continue
+
+            if item_id not in seen:
+                seen.add(item_id)
+                item_ids.append(item_id)
+
+    if not item_ids:
+        raise ValueError(f"no valid item IDs found in CSV: {path}")
+
+    return sorted(item_ids)
+
+
 def main(
     cfg_path: Annotated[Path, Option("--config", help="Config file path.")] = Path("config.yaml"),
     out_csv: Annotated[Path, Option("--out-csv", help="The output CSV file to save.")] = Path("items.csv"),
+    inp_csv: Annotated[
+        OptionalPath,
+        Option(
+            "--inp-csv",
+            help="Optional input CSV containing an itemid column. "
+            "When provided, scrub will scrape exactly those item IDs.",
+        ),
+    ] = None,
     server_str: Annotated[str, ServerIDOption] = ServerID.ASURA.name,
     cat_urls: Annotated[OptionalStrList, Option("--cat-url", help="Preset category URLs.")] = None,
     item_ids: Annotated[OptionalIntList, Option("--item-id", help="Preset item IDs.")] = None,
@@ -34,9 +87,7 @@ def main(
     should_backup: Annotated[bool, Option("--backup", help="Backup output CSV?")] = False,
     cache: Annotated[OptionalPath, Option("--cache", help="A directory to cache the fetched data")] = None,
 ) -> None:
-    """
-    Download a list of item prices from ffxiah.com and save to a CSV file.
-    """
+    """Download a list of item prices from ffxiah.com and save to a CSV file."""
     from ffxiahbot.common import backup
     from ffxiahbot.config import Config
     from ffxiahbot.itemlist import ItemList
@@ -45,36 +96,64 @@ def main(
     config: Config = Config.from_yaml(cfg_path)
     logger.info("%s", config.model_dump_json(indent=2))
 
-    # check output file name validity
     if not out_csv.suffix.lower() == ".csv":
         raise ValueError("--out-csv file must be a CSV file!")
+
+    if inp_csv is not None and not Path(inp_csv).suffix.lower() == ".csv":
+        raise ValueError("--inp-csv file must be a CSV file!")
 
     if not overwrite and not should_backup and out_csv.exists():
         logger.error("output file already exists!\n\t%s", out_csv)
         logger.error("please use --overwrite or --backup")
         raise Exit(-1)
 
-    # scrub data
-    scrubber = FFXIAHScrubber(server=cast(ServerID, ServerID[server_str.upper()]), cache=cache)
-    results, failed = asyncio.run(scrubber.scrub(cat_urls=cat_urls, item_ids=item_ids))
+    csv_item_ids: list[int] = []
+    if inp_csv is not None:
+        csv_item_ids = _load_item_ids_from_csv(Path(inp_csv))
+        logger.info("loaded %d item IDs from %s", len(csv_item_ids), inp_csv)
+
+    cli_item_ids = sorted(set(item_ids or []))
+
+    # If CSV IDs are present, they become the primary reference.
+    # CLI --item-id values are appended and deduped.
+    merged_item_ids: list[int] | None = None
+    if csv_item_ids or cli_item_ids:
+        merged_item_ids = sorted(set(csv_item_ids).union(cli_item_ids))
+        if cat_urls:
+            logger.warning("--cat-url ignored because explicit item IDs were provided")
+
+    scrubber = FFXIAHScrubber(
+        server=cast(ServerID, ServerID[server_str.upper()]),
+        cache=cache,
+    )
+
+    results, failed = asyncio.run(
+        scrubber.scrub(
+            cat_urls=None if merged_item_ids is not None else cat_urls,
+            item_ids=merged_item_ids,
+        )
+    )
 
     if results:
-        # create item list from data
         item_list = ItemList()
+
         with progress_bar("[red]Validate Items...", total=len(results)) as (progress, progress_task):
             for itemid in sorted(results.keys()):
-                kwargs = augment_item_info(results[itemid], stock_single=stock_single, stock_stacks=stock_stacks)
+                kwargs = augment_item_info(
+                    results[itemid],
+                    stock_single=stock_single,
+                    stock_stacks=stock_stacks,
+                )
                 progress.update(progress_task, advance=1)
                 item_list.add(itemid, **kwargs)
 
-        # backup file
         if should_backup:
             backup(out_csv, copy=True)
 
-        # overwrites if exists, but we checked already
         item_list.save_csv(out_csv)
     else:
         raise RuntimeError("no items were scrubbed!")
 
     if failed:
+        logger.warning("failed to scrub %d item IDs", len(failed))
         raise RuntimeError("not all item ids were scrubbed, but a CSV was still saved!")

--- a/ffxiahbot/scrubbing/ffxiah.py
+++ b/ffxiahbot/scrubbing/ffxiah.py
@@ -24,7 +24,6 @@ REGEX_CATEGORY: re.Pattern = re.compile(r"/browse/(\d+)/?.*")
 REGEX_ITEM: re.Pattern = re.compile(r"/item/(\d+)")
 REGEX_NAME: re.Pattern = re.compile(r"(.*?)\s*-?\s*(FFXIAH)?\.(com)?")
 
-
 FailedType = dict[int, Exception]
 ResultType = dict[int, dict[str, Any]]
 ItemIDsType = list[int] | set[int] | tuple[int, ...]
@@ -33,12 +32,11 @@ CatURLsType = list[str] | set[str] | tuple[str, ...]
 
 @dataclass()
 class FFXIAHScrubber(Scrubber):
-    """
-    Get item data from the ffxiah.com website.
-    """
+    """Get item data from the ffxiah.com website."""
 
     #: The FFXI server
     server: ServerID = ServerID.BAHAMUT
+
     #: The cache directory
     cache: OptionalPath = None
 
@@ -50,8 +48,9 @@ class FFXIAHScrubber(Scrubber):
         """
         Get item metadata main function.
 
-        The item ids can be loaded from category urls or simply passed as a list.  The urls
-        can be generated automatically, in which case all possible items will be downloaded.
+        The item ids can be loaded from category urls or simply passed as a list.
+        The urls can be generated automatically, in which case all possible items
+        will be downloaded.
 
         Args:
             cat_urls: A preset list of category URLs.
@@ -65,13 +64,11 @@ class FFXIAHScrubber(Scrubber):
             if not item_ids:
                 if not cat_urls:
                     cat_urls = await self._get_category_urls(session)
-
-                logger.debug("# urls = %d", len(cat_urls))
+                    logger.debug("# urls = %d", len(cat_urls))
                 item_ids = await self._get_item_ids(session, cat_urls)
             else:
                 logger.debug("using passed ids")
                 item_ids = sorted(set(item_ids))
-
                 if cat_urls:
                     logger.warning("passed urls ignored")
 
@@ -79,48 +76,54 @@ class FFXIAHScrubber(Scrubber):
             logger.debug("expect count = %d", len(item_ids))
             logger.debug("passed count = %d", len(results))
             logger.debug("failed count = %d", len(failed))
-
             return results, failed
 
     # step 1
     async def _get_category_urls(self, session: aiohttp.ClientSession) -> list[str]:
         """
-        Parse http://www.ffxiah.com/browse to get URLs of the form http://www.ffxiah.com/{CategoryNumber}.
+        Parse http://www.ffxiah.com/browse to get URLs of the form
+        http://www.ffxiah.com/{CategoryNumber}.
         """
         logger.debug("getting category urls")
-
-        # the browse section of FFXIAH has a list of urls with category numbers
         logger.debug("open %s", path := "http://www.ffxiah.com/browse")
         soup = await self.soup(session, path)
 
         def _() -> Iterable[str]:
+            seen: set[int] = set()
+
             for tag in soup.find_all("a"):
-                if tag.has_attr("href"):
-                    href = tag.get("href")
-                    match = REGEX_CATEGORY.match(href)
-                    if match:
-                        try:
-                            category = int(match.group(1))
-                            if category < 240:
-                                yield f"http://www.ffxiah.com{href}"
-                                logger.debug("category %s", href)
-                            else:
-                                logger.debug("skipping %s", href)
+                if not tag.has_attr("href"):
+                    continue
 
-                        except (ValueError, IndexError):
-                            logger.exception("failed to extract category")
-                    else:
-                        logger.debug("ignoring %s", href)
+                href = tag.get("href")
+                match = REGEX_CATEGORY.match(href)
+                if not match:
+                    logger.debug("ignoring %s", href)
+                    continue
 
-        return sorted(_(), key=lambda x: list(map(float, re.findall(r"\d+", x))))
+                try:
+                    category = int(match.group(1))
+                except (ValueError, IndexError):
+                    logger.exception("failed to extract category")
+                    continue
+
+                # Upstream capped this at < 240. Removing that cap lets us
+                # follow all browse categories FFXIAH exposes.
+                if category in seen:
+                    continue
+
+                seen.add(category)
+                logger.debug("category %s", href)
+                yield f"http://www.ffxiah.com{href}"
+
+        return sorted(set(_()), key=lambda x: list(map(float, re.findall(r"\d+", x))))
 
     # step 2
     async def _get_item_ids(self, session: aiohttp.ClientSession, urls: CatURLsType) -> list[int]:
-        """
-        Scrub urls of the form http://www.ffxiah.com/{CategoryNumber} for itemids.
-        """
+        """Scrub urls of the form http://www.ffxiah.com/{CategoryNumber} for itemids."""
         tasks = []
         logger.info("getting itemids")
+
         for i, cat_url in enumerate(urls):
             logger.info("category %02d/%02d : %s", i + 1, len(urls), cat_url)
             tasks.append(asyncio.create_task(self._get_itemids_for_category_url(session, cat_url)))
@@ -129,76 +132,68 @@ class FFXIAHScrubber(Scrubber):
 
     # step 2.1
     async def _get_itemids_for_category_url(self, session: aiohttp.ClientSession, url: str) -> Iterable[int]:
-        """
-        Scrub url of the form http://www.ffxiah.com/{CategoryNumber} for itemids.
-        """
-        # create tag soup
+        """Scrub url of the form http://www.ffxiah.com/{CategoryNumber} for itemids."""
         soup = await self.soup(session, url)
 
         def _() -> Iterable[int]:
-            # look for table class
             table = soup.find("table", class_="stdlist")
             if not table:
-                logger.error("failed to parse <table>")
+                logger.error("failed to parse table for category %s", url)
                 return
 
-            # look for table body
             tbody = table.find("tbody")
             if not tbody:
-                logger.error("failed to parse <tbody>")
+                logger.error("failed to parse tbody for category %s", url)
                 return
 
-            # look for table rows
             trs = cast(Tag, tbody).find_all("tr")
             if not trs:
-                logger.error("failed to parse <tr>")
+                logger.error("failed to parse table rows for category %s", url)
                 return
 
-            # loop table rows
             count = 0
             for j, row in enumerate(trs):
-                # look for 'a' tag
                 a = row.find("a")
-
-                if a is not None:
-                    # look for href attr
-                    href = a.get("href")
-
-                    if href is not None:
-                        # make sure href matches /item/{number}
-                        if (match := REGEX_ITEM.match(href)) is None:
-                            logger.error("failed to extract itemid!\n\n\trow %d of %s\n\n%s\n\n", j, url, row)
-                        else:
-                            item = int(match.group(1))
-                            count += 1
-                            yield item
-                    else:
-                        logger.error("failed to extract href!\n\n\trow %d of %s\n\n%s\n\n", j, url, row)
-                else:
+                if a is None:
                     logger.error("failed to extract 'a' tag!\n\n\trow %d of %s\n\n%s\n\n", j, url, row)
+                    continue
 
-            # make sure we found something
+                href = a.get("href")
+                if href is None:
+                    logger.error("failed to extract href!\n\n\trow %d of %s\n\n%s\n\n", j, url, row)
+                    continue
+
+                match = REGEX_ITEM.match(href)
+                if match is None:
+                    logger.error("failed to extract itemid!\n\n\trow %d of %s\n\n%s\n\n", j, url, row)
+                    continue
+
+                item = int(match.group(1))
+                count += 1
+                yield item
+
             if not count:
-                logger.error("could not find any itemids!")
+                logger.error("could not find any itemids for category %s", url)
 
         return set(_())
 
     # step 3
     async def _get_item_data(self, session: aiohttp.ClientSession, itemids: list[int]) -> tuple[ResultType, FailedType]:
-        """
-        Get metadata for many items.
-        """
+        """Get metadata for many items."""
         logger.info("getting data")
+
         tasks = {
-            itemid: asyncio.create_task(self._get_item_data_for_itemid(session, itemid, index=i, total=len(itemids)))
+            itemid: asyncio.create_task(
+                self._get_item_data_for_itemid(session, itemid, index=i, total=len(itemids))
+            )
             for i, itemid in enumerate(itemids)
         }
 
         results, failed = {}, {}
+
         with progress_bar("[red]Fetching Items...", total=len(itemids)) as (progress, progress_task):
             for i, (itemid, task) in enumerate(tasks.items()):
                 progress.update(progress_task, advance=1)
-                # noinspection PyBroadException
                 try:
                     results[itemid] = await task
                     logger.info("item %06d/%06d : %06d", i, len(itemids), itemid)
@@ -208,41 +203,37 @@ class FFXIAHScrubber(Scrubber):
                     if len(failed) > int(os.environ.get("FFXIAHBOT_SCRUB_MAX_FAILURES", 10)):
                         logger.error("too many failures!")
                         raise typer.Exit(-1) from None
+
         return results, failed
 
     def _cache_sub(self, itemid: int) -> Path:
-        """
-        Create cache subdirectory.
-        """
+        """Create cache subdirectory."""
         if self.cache is None:
             raise RuntimeError("cache is not set!")
-
         return cast(Path, self.cache).joinpath(f"{self.server.value}", f"{itemid // 1000}", f"{itemid}")
 
     # step 3.1
     async def _get_item_data_for_itemid(
-        self, session: aiohttp.ClientSession, itemid: int, index: int = 0, total: int = 0
+        self,
+        session: aiohttp.ClientSession,
+        itemid: int,
+        index: int = 0,
+        total: int = 0,
     ) -> dict[str, Any]:
-        """
-        Get metadata for single item.
-        """
+        """Get metadata for single item."""
         percent = float(index) / float(total) * 100.0 if total > 0 else 0.0
-
         data: dict[str, Any] = {"name": None, "itemid": itemid}
         url = f"http://www.ffxiah.com/item/{itemid}"
 
-        # load cache
         if self.cache is not None:
             cache_stub = self._cache_sub(itemid)
             if (cache_path := cache_stub.with_suffix(".json")).exists():
                 logger.debug("load server=%s (%06d/%06d,%6.2f) %s", self.server, index, total, percent, url)
                 return cast(dict[str, Any], json.loads(cache_path.read_text()))
 
-        # create tag soup
         logger.debug("open server=%s (%06d/%06d,%6.2f) %s", self.server, index, total, percent, url)
         soup = await self.soup(session, url, data={"sid": self.server.value})
 
-        # extract name
         if (
             soup.title is not None
             and soup.title.text is not None
@@ -252,7 +243,6 @@ class FFXIAHScrubber(Scrubber):
         else:
             data.update(name=None)
 
-        # extract numbers
         for tag in soup.find_all("span", "number-format"):
             try:
                 key = tag.parent.find_previous_sibling().text.lower()
@@ -260,15 +250,12 @@ class FFXIAHScrubber(Scrubber):
             except (AttributeError, ValueError):
                 pass
 
-        # extract rate
         for tag in soup.find_all("span", "sales-rate"):
             with contextlib.suppress(AttributeError, ValueError):
                 data["rate"] = float(tag.text)
 
-        # fix key
         data = self._fix_stack_price_key(data)
 
-        # save cache
         if self.cache is not None:
             cache_stub = self._cache_sub(itemid)
             cache_stub.parent.mkdir(parents=True, exist_ok=True)
@@ -279,45 +266,30 @@ class FFXIAHScrubber(Scrubber):
     # step 3.1.2
     @staticmethod
     def _fix_stack_price_key(data: dict[str, Any]) -> dict[str, Any]:
-        """
-        Fix dictionary key.
-        """
+        """Fix dictionary key."""
         new_key = r"stack price"
-
         for key in list(data.keys()):
             if "stack" in key.lower():
                 data[new_key] = data[key]
-
         return data
 
 
 def augment_item_info(item_info: dict[str, Any], **kwargs: Any) -> dict:
-    """
-    Extract item data from scrubbed info.
-    """
-    # singles
+    """Extract item data from scrubbed info."""
     try:
         price_single, sell_single = item_info["median"], True
-
-        # do not sell items without a price
         if price_single <= 0:
             price_single, sell_single = 0, False
-
     except KeyError:
         price_single, sell_single = 0, False
 
-    # stacks
     try:
         price_stacks, sell_stacks = item_info["stack price"], True
-
-        # do not sell items without a price
         if price_stacks <= 0:
             price_stacks, sell_stacks = 0, False
-
     except KeyError:
         price_stacks, sell_stacks = 0, False
 
-    # the name doesn't really matter
     try:
         name = item_info["name"]
     except KeyError:
@@ -337,5 +309,4 @@ def augment_item_info(item_info: dict[str, Any], **kwargs: Any) -> dict:
         "rate_stacks": 1.0,
     }
     result.update(**kwargs)
-
     return result


### PR DESCRIPTION
This accomplishes 2 primary things: 

 1. add --inp-csv support to scrub, so you can scrub a custom-tailored list of itemid's. This is particualrly useful for servers that are primarily 75-era content, but may also have additional content enabled that relies on post-75 era items for quests.
 -- if supplied, the scrubber will pull the provided itemid's
 -- if not supplied, the scrubbers default behavior takes over

2. remove the < 240 category cap so category discovery can pull all browse categories